### PR TITLE
Remove non-printable characters from index.js.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-﻿/*!
+/*!
  * ncc v0.2.x
  *
  * Copyright 2014 Stefan Keim (indus)


### PR DESCRIPTION
@indus: There's some non-printable characters in index.js that are causing a lot of things to blow up for me. The github diff doesn't do it justice. See the proper diff below:

``` diff
diff --git a/index.js b/index.js
index c81e7e2..50f5297 100644
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-﻿<U+FEFF>/*!
+/*!
  * ncc v0.2.x
  *
  * Copyright 2014 Stefan Keim (indus)
@@ -8,4 +8,4 @@
  * Date: 2014-05-13
  */

-module.exports = require('./lib/ncc');
\ No newline at end of file
+module.exports = require('./lib/ncc');
```
